### PR TITLE
Add the --ouput option for the pop command

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -50,6 +50,10 @@ pub enum Commands {
         /// Pop the most recent item with the specified tags (comma-separated)
         #[arg(long, short = 't', value_delimiter = ',')]
         tags: Option<Vec<String>>,
+
+        /// Custom output directory path (defaults to current directory)
+        #[arg(long = "output", short = 'o')]
+        output: Option<String>,
     },
 
     /// List all items in the stack

--- a/src/cli/pop.rs
+++ b/src/cli/pop.rs
@@ -7,24 +7,34 @@ use crate::fs;
 use crate::utils::numbers::parse_number_range;
 
 /// Pop items from the stack and restore them to the current directory or a specified output directory.
-pub fn pop(numbers: Option<String>, tags: Option<Vec<String>>, output: Option<String>) -> Result<()> {
+pub fn pop(
+    numbers: Option<String>,
+    tags: Option<Vec<String>>,
+    output: Option<String>,
+) -> Result<()> {
     let tag_vec = tags.unwrap_or_default();
     let filter_by_tags = !tag_vec.is_empty();
-    
+
     // Determine output directory (default to current directory if not specified)
     let output_dir = match &output {
         Some(path) => {
             let dir_path = std::path::PathBuf::from(path);
             // Check if the output directory exists and is a directory
             if !dir_path.exists() {
-                return Err(anyhow!("Output directory does not exist: {}", dir_path.display()));
+                return Err(anyhow!(
+                    "Output directory does not exist: {}",
+                    dir_path.display()
+                ));
             }
             if !dir_path.is_dir() {
-                return Err(anyhow!("Specified output path is not a directory: {}", dir_path.display()));
+                return Err(anyhow!(
+                    "Specified output path is not a directory: {}",
+                    dir_path.display()
+                ));
             }
             dir_path
-        },
-        None => env::current_dir()?
+        }
+        None => env::current_dir()?,
     };
 
     // Connect to database

--- a/src/db/item.rs
+++ b/src/db/item.rs
@@ -29,8 +29,9 @@ impl StackItem {
         let naive_dt = chrono::NaiveDateTime::parse_from_str(&pushed_at_str, "%Y-%m-%d %H:%M:%S")
             .map_err(|e| anyhow!("Error parsing date: {}", e))?;
         // First interpret as UTC, then convert to local time
-        let pushed_at = chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(naive_dt, chrono::Utc)
-            .with_timezone(&Local);
+        let pushed_at =
+            chrono::DateTime::<chrono::Utc>::from_naive_utc_and_offset(naive_dt, chrono::Utc)
+                .with_timezone(&Local);
 
         Ok(StackItem {
             id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,11 @@ fn main() -> Result<()> {
             cli::push::push(&path, tags)?;
         }
 
-        Commands::Pop { numbers, tags, output } => {
+        Commands::Pop {
+            numbers,
+            tags,
+            output,
+        } => {
             cli::pop::pop(numbers, tags, output)?;
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,8 +20,8 @@ fn main() -> Result<()> {
             cli::push::push(&path, tags)?;
         }
 
-        Commands::Pop { numbers, tags } => {
-            cli::pop::pop(numbers, tags)?;
+        Commands::Pop { numbers, tags, output } => {
+            cli::pop::pop(numbers, tags, output)?;
         }
 
         Commands::List { tags } => {


### PR DESCRIPTION
#3 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The Pop command now accepts an optional output directory, allowing you to specify a custom location for restored items. The command defaults to the current directory when no output path is provided and includes enhanced error handling to ensure the path is valid.
- **Style**
	- Minor formatting adjustments made for improved readability in the StackItem implementation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->